### PR TITLE
fix(ui): render BigInt values as strings in results table

### DIFF
--- a/packages/ui/src/components/ResultsTable.tsx
+++ b/packages/ui/src/components/ResultsTable.tsx
@@ -35,7 +35,10 @@ const ResultsTable: Component<ResultsTableProps> = (props) => {
     return Object.keys(firstItem).map((key) => ({
       accessorKey: key,
       header: key,
-      cell: (info) => info.getValue(),
+      cell: (info) => {
+        const value = info.getValue();
+        return typeof value === "bigint" ? value.toString() : value;
+      },
     }));
   });
 


### PR DESCRIPTION
Fixes #9.

BigInt values were failing to render in the results table. This PR adds a check to convert BigInt values to strings before rendering.

---
*This PR was created by an AI agent on behalf of @sushruth.*